### PR TITLE
Fix: Create log_dir if it does not exist, enabling writing of tensorboard logs

### DIFF
--- a/train_flow.py
+++ b/train_flow.py
@@ -51,7 +51,9 @@ class Trainer(object):
         self.checkpoint_name, self.best_name = "current", "best"
         self.cur_epoch = 0
         self.training_best, self.eval_best = {}, {}
-        self.viz = SummaryWriter(osp.join(exp_base, 'log'))
+        log_dir = osp.join(exp_base, 'log')
+        os.makedirs(log_dir, exist_ok=True)
+        self.viz = SummaryWriter(log_dir)
 
 
     def _train_it(self, it, batch):

--- a/train_seg.py
+++ b/train_seg.py
@@ -39,7 +39,9 @@ class Trainer(object):
         self.checkpoint_name, self.best_name = "current", "best"
         self.cur_epoch = 0
         self.training_best, self.eval_best = {}, {}
-        self.viz = SummaryWriter(osp.join(exp_base, 'log'))
+        log_dir = osp.join(exp_base, 'log')
+        os.makedirs(log_dir, exist_ok=True)
+        self.viz = SummaryWriter(log_dir)
 
 
     def _train_it(self, it, batch, aug_transform=False):

--- a/train_seg_sup.py
+++ b/train_seg_sup.py
@@ -37,7 +37,9 @@ class Trainer(object):
         self.checkpoint_name, self.best_name = "current", "best"
         self.cur_epoch = 0
         self.training_best, self.eval_best = {}, {}
-        self.viz = SummaryWriter(osp.join(exp_base, 'log'))
+        log_dir = osp.join(exp_base, 'log')
+        os.makedirs(log_dir, exist_ok=True)
+        self.viz = SummaryWriter(log_dir)
 
 
     def _train_it(self, it, batch, aug_transform=False):


### PR DESCRIPTION
For me, the experiments did not create any tensorboard files. This is due to the fact that the log_dir does not exist. This PR will enable the creation of tensorboard logs by creating the log_dir first.