### PR TITLE
Refactor: Update loss_dict merging method to use update() for compatibility

### DIFF
--- a/train_flow.py
+++ b/train_flow.py
@@ -75,7 +75,7 @@ class Trainer(object):
             flow_preds = self.flownet(pc1, pc2, pc1, pc2, iters=self.model_iters)
             loss, loss_dict = self.criterion(pc1, pc2, flow_preds)
             epe_dict = epe_metric(flow, flow_preds)
-            loss_dict = loss_dict | epe_dict
+            loss_dict.update(epe_dict)
 
         # Backward
         try:
@@ -110,7 +110,7 @@ class Trainer(object):
                     flow_preds = self.flownet(pc1, pc2, pc1, pc2, iters=self.model_iters)
                     loss, loss_dict = self.criterion(pc1, pc2, flow_preds)
                     epe_dict = epe_metric(flow, flow_preds)
-                    loss_dict = loss_dict | epe_dict
+                    loss_dict.update(epe_dict)
 
                 total_loss += loss.item()
                 count += 1


### PR DESCRIPTION
the operator "|" for dict support after python 3.9

however, if we run this repo using official pytorch docker image[1.9.1-cuda11.1-cudnn8](https://hub.docker.com/layers/pytorch/pytorch/1.9.1-cuda11.1-cudnn8-devel/images/sha256-fd8fcd6e1196d8965657b04e7dfb666046063904b767c1fd75df8039fe0ada17), the default python version is 3.7, which will causing compatibility issues,

this PR replace 
```python 
 loss_dict = loss_dict | epe_dict
```
with 
```
loss_dict.update(epe_dict)
```
to make repo can be run under python3.7